### PR TITLE
Change php-http/message-factory → psr/http-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php-http/client-implementation": "^1.0",
     "php-http/discovery": "^1.0",
     "php-http/message": "^1.4",
-    "php-http/message-factory": "^1.0"
+    "psr/http-factory": "^1.0"
   },
   "require-dev": {
     "freezy-bee/nette-caching-psr6": "^2.0",


### PR DESCRIPTION
* Package php-http/message-factory is abandoned, you should avoid using it. Use psr/http-factory instead.
* This package is abandoned and no longer maintained. The author suggests using the psr/http-factory package instead.
* https://packagist.org/packages/php-http/message-factory